### PR TITLE
Use more robust shebang lines

### DIFF
--- a/camomilla
+++ b/camomilla
@@ -1,4 +1,4 @@
-#!/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (c) 2016-2017 Vittorio Romeo
 # License: MIT License

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/bin/python3
+#!/usr/bin/env python3
 
 from setuptools import setup, find_packages
 


### PR DESCRIPTION
Many systems have not merged /bin and /usr/bin and so are unlikely to
have a python3 binary located in /bin. Use the de facto standard of
specifying a path to /usr/bin/env to allow it to search PATH to find the
python3 binary.