### PR TITLE
use time.perf_counter() instead of time.clock()

### DIFF
--- a/camomilla
+++ b/camomilla
@@ -388,7 +388,7 @@ class Camomilla:
     def process(self, istream, ostream, temp_cache):
         if self.enableProcessByLine():
             # Process error line by line
-            lastTime = time.clock()
+            lastTime = time.perf_counter()
             while True:
                 src = istream.readline()
 
@@ -398,8 +398,8 @@ class Camomilla:
                 self._processImpl(src, ostream, temp_cache)
 
                 # Flush once per second
-                t = time.clock()
-                if t != lastTime:
+                t = time.perf_counter()
+                if t - lastTime >= 1.0:
                     ostream.flush()
                 lastTime = t
         else:


### PR DESCRIPTION
This fixes a deprecation warning:

./camomilla:391: DeprecationWarning: time.clock has been deprecated in Python 3.3 and will be removed from Python 3.8: use time.perf_counter or time.process_time instead
  lastTime = time.clock()

Also change slightly the logic to effectively flush once per second
rather than whenever the timer ticks.